### PR TITLE
Return to mainline ResuireJS/CommonJS imports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    - run: npm test
+    - run: make test
 
   build-site:
 
@@ -43,5 +43,4 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm ci
-    - run: npm build
+    - run: make build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,14 +10,13 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  ci:
 
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         node-version: [16.x, 18.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
     - uses: actions/checkout@v3
@@ -28,3 +27,21 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm test
+
+  build-site:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm build

--- a/app/javascripts/board.js
+++ b/app/javascripts/board.js
@@ -1,4 +1,4 @@
-export default class Board {
+class Board {
   _tiles = []
 
   constructor(tiles) {
@@ -31,3 +31,5 @@ export default class Board {
     return this.tiles.find(tile => tile.row === row && tile.column === column)
   }
 }
+
+module.exports = Board

--- a/app/javascripts/game.js
+++ b/app/javascripts/game.js
@@ -1,4 +1,4 @@
-export default class Game {
+class Game {
   board
   player1
   player2
@@ -29,3 +29,5 @@ export default class Game {
     return (this.currentPlayer === this.player1 ? this.player2 : this.player1)
   }
 }
+
+module.exports = Game

--- a/app/javascripts/tile.js
+++ b/app/javascripts/tile.js
@@ -1,4 +1,4 @@
-export default class Tile {
+class Tile {
   row
   column
 
@@ -12,3 +12,5 @@ export default class Tile {
     return !!this.player
   }
 }
+
+module.exports = Tile

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "Experimenting with different approaches to JavaScript implementations for a straightforward Tic-Tac-Toe game.",
   "main": "app/index.webc",
-  "type": "module",
   "scripts": {
     "build": "npx @11ty/eleventy",
     "clean": "rm -rf _site",

--- a/test/board.js
+++ b/test/board.js
@@ -75,13 +75,9 @@ describe("Board", () => {
 
       const board = new Board()
 
-      console.log("test assert.throws start")
       assert.throws(() => {
-        console.log("TEST assert.throws inside before")
         board.tiles = [original, duplicate]
-        console.log("TEST assert.throws inside after")
       })
-      console.log("test assert.throws done")
     })
   })
 })

--- a/test/board.js
+++ b/test/board.js
@@ -1,6 +1,6 @@
-import Board from "../app/javascripts/board.js"
-import Tile from "../app/javascripts/tile.js"
-import {assert} from "chai"
+const Board = require("../app/javascripts/board.js")
+const Tile = require("../app/javascripts/tile.js")
+const assert = require("chai").assert
 
 describe("Board", () => {
   describe("new", () => {

--- a/test/game.js
+++ b/test/game.js
@@ -1,8 +1,8 @@
-import Game from "../app/javascripts/game.js"
-import Board from "../app/javascripts/board.js"
-import Tile from "../app/javascripts/tile.js"
+const Game = require("../app/javascripts/game.js")
+const Board = require("../app/javascripts/board.js")
+const Tile = require("../app/javascripts/tile.js")
 
-import {assert} from "chai"
+const assert = require("chai").assert
 
 describe("Game", () => {
   describe("new", () => {

--- a/test/tile.js
+++ b/test/tile.js
@@ -1,5 +1,5 @@
-import Tile from "../app/javascripts/tile.js"
-import {assert} from "chai"
+const Tile = require("../app/javascripts/tile.js")
+const assert = require("chai").assert
 
 describe("Tile", () => {
   describe("new", () => {


### PR DESCRIPTION
Because:

* Eleventy doesn't roll with ES modules yet
* I don't want some things with ES modules and other things with old-style require

Solution:

* Just go back to old-style require everywhere
* Also build Eleventy in CI to avoid breaking it again
