### PR TITLE
Fix that tiles aren't rendering in Chrome

### DIFF
--- a/app/javascripts/vanilla-component.js
+++ b/app/javascripts/vanilla-component.js
@@ -17,9 +17,11 @@ class GameTile extends HTMLElement {
     this.button = document.createElement("button")
     this.button.classList.add("game--tile")
     this.button.addEventListener("click", this.play.bind(this))
+    console.log("GameTile.constructor", {this: this})
   }
 
   connectedCallback() {
+    console.log("GameTile.connectedCallback", {this: this})
     this.appendChild(this.button)
   }
 
@@ -70,7 +72,7 @@ class GameTile extends HTMLElement {
   }
 }
 
-customElements.define("game-tile", GameTile, {extends: "button"})
+customElements.define("game-tile", GameTile)
 
 class TicTacToe extends HTMLElement {
   game
@@ -145,6 +147,7 @@ class TicTacToe extends HTMLElement {
       return existing
     } else {
       const tileElement = document.createElement("game-tile")
+      console.log("TicTacToe._findOrCreateTile created tile", {tileElement})
       tileElement.dataset.row = tile.row
       tileElement.dataset.column = tile.column
       tileElement.dataset.index = index


### PR DESCRIPTION
Because:

* The `game-tile` elements are in the DOM, but their behavior doesn't appear to trigger since the buttons never appear.
* Adding logging to `GameTile`'s constructor and `connectedCallback` didn't appear to trigger

Solution:

* Remove `{extends: "button"}` from the custom element's definition
* That was added to try to get them to behave like buttons by default (per [the MDN docs][extend-default-elements] how you're supposed to create customized versions of native elements) which didn't have the intended effect (e.g., didn't give button UI, nor respect `disabled` like the `button` element) and was now unnecessary since it adds an actual `button` as a child when connected to the DOM anyway.

[extend-default-elements]:https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#customized_built-in_elements
